### PR TITLE
Build single precision HSL routines if source files exist in coinhsl …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,17 +12,29 @@ libcoinhsl_la_SOURCES = coinhsl/common/deps.f
 if COIN_HAS_MC19
   libcoinhsl_la_SOURCES += coinhsl/mc19/mc19d.f
 endif
+if COIN_HAS_MC19S
+  libcoinhsl_la_SOURCES += coinhsl/mc19/mc19s.f
+endif
 
 if COIN_HAS_MA27
   libcoinhsl_la_SOURCES += coinhsl/ma27/ma27d.f
+endif
+if COIN_HAS_MA27S
+  libcoinhsl_la_SOURCES += coinhsl/ma27/ma27s.f
 endif
 
 if COIN_HAS_MA28
   libcoinhsl_la_SOURCES += coinhsl/ma28/ma28d.f
 endif
+if COIN_HAS_MA28S
+  libcoinhsl_la_SOURCES += coinhsl/ma28/ma28s.f
+endif
 
 if COIN_HAS_MA57
   libcoinhsl_la_SOURCES += coinhsl/ma57/ma57d.f
+endif
+if COIN_HAS_MA57S
+  libcoinhsl_la_SOURCES += coinhsl/ma57/ma57s.f
 endif
 
 if COIN_HAS_DEPSF90
@@ -38,15 +50,27 @@ if COIN_HAS_HSL_MA77
   libcoinhsl_la_SOURCES += coinhsl/hsl_ma77/hsl_ma77d.f90 coinhsl/hsl_ma77/C/hsl_ma77d_ciface.f90
   includecoin_HEADERS += coinhsl/hsl_ma77/C/hsl_ma77d.h
 endif
+if COIN_HAS_HSL_MA77S
+  libcoinhsl_la_SOURCES += coinhsl/hsl_ma77/hsl_ma77s.f90 coinhsl/hsl_ma77/C/hsl_ma77s_ciface.f90
+  # includecoin_HEADERS += coinhsl/hsl_ma77/C/hsl_ma77s.h
+endif
 
 if COIN_HAS_HSL_MA86
   libcoinhsl_la_SOURCES += coinhsl/hsl_ma86/hsl_ma86d.f90 coinhsl/hsl_ma86/C/hsl_ma86d_ciface.f90
   includecoin_HEADERS += coinhsl/hsl_ma86/C/hsl_ma86d.h
 endif
+if COIN_HAS_HSL_MA86S
+  libcoinhsl_la_SOURCES += coinhsl/hsl_ma86/hsl_ma86s.f90 coinhsl/hsl_ma86/C/hsl_ma86s_ciface.f90
+  # includecoin_HEADERS += coinhsl/hsl_ma86/C/hsl_ma86s.h
+endif
 
 if COIN_HAS_HSL_MA97
   libcoinhsl_la_SOURCES += coinhsl/hsl_ma97/hsl_ma97d.f90 coinhsl/hsl_ma97/C/hsl_ma97d_ciface.f90
   includecoin_HEADERS += coinhsl/hsl_ma97/C/hsl_ma97d.h
+endif
+if COIN_HAS_HSL_MA97S
+  libcoinhsl_la_SOURCES += coinhsl/hsl_ma97/hsl_ma97s.f90 coinhsl/hsl_ma97/C/hsl_ma97s_ciface.f90
+  # includecoin_HEADERS += coinhsl/hsl_ma97/C/hsl_ma97s.h
 endif
 
 libcoinhsl_la_SOURCES += metis_adapter.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -95,18 +95,25 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 @COIN_HAS_MC19_TRUE@am__append_1 = coinhsl/mc19/mc19d.f
-@COIN_HAS_MA27_TRUE@am__append_2 = coinhsl/ma27/ma27d.f
-@COIN_HAS_MA28_TRUE@am__append_3 = coinhsl/ma28/ma28d.f
-@COIN_HAS_MA57_TRUE@am__append_4 = coinhsl/ma57/ma57d.f
-@COIN_HAS_DEPSF90_TRUE@am__append_5 = coinhsl/common/deps90.f90
-@COIN_HAS_HSL_MC68_TRUE@am__append_6 = coinhsl/hsl_mc68/C/hsl_mc68i_ciface.f90
-@COIN_HAS_HSL_MC68_TRUE@am__append_7 = coinhsl/hsl_mc68/C/hsl_mc68i.h
-@COIN_HAS_HSL_MA77_TRUE@am__append_8 = coinhsl/hsl_ma77/hsl_ma77d.f90 coinhsl/hsl_ma77/C/hsl_ma77d_ciface.f90
-@COIN_HAS_HSL_MA77_TRUE@am__append_9 = coinhsl/hsl_ma77/C/hsl_ma77d.h
-@COIN_HAS_HSL_MA86_TRUE@am__append_10 = coinhsl/hsl_ma86/hsl_ma86d.f90 coinhsl/hsl_ma86/C/hsl_ma86d_ciface.f90
-@COIN_HAS_HSL_MA86_TRUE@am__append_11 = coinhsl/hsl_ma86/C/hsl_ma86d.h
-@COIN_HAS_HSL_MA97_TRUE@am__append_12 = coinhsl/hsl_ma97/hsl_ma97d.f90 coinhsl/hsl_ma97/C/hsl_ma97d_ciface.f90
-@COIN_HAS_HSL_MA97_TRUE@am__append_13 = coinhsl/hsl_ma97/C/hsl_ma97d.h
+@COIN_HAS_MC19S_TRUE@am__append_2 = coinhsl/mc19/mc19s.f
+@COIN_HAS_MA27_TRUE@am__append_3 = coinhsl/ma27/ma27d.f
+@COIN_HAS_MA27S_TRUE@am__append_4 = coinhsl/ma27/ma27s.f
+@COIN_HAS_MA28_TRUE@am__append_5 = coinhsl/ma28/ma28d.f
+@COIN_HAS_MA28S_TRUE@am__append_6 = coinhsl/ma28/ma28s.f
+@COIN_HAS_MA57_TRUE@am__append_7 = coinhsl/ma57/ma57d.f
+@COIN_HAS_MA57S_TRUE@am__append_8 = coinhsl/ma57/ma57s.f
+@COIN_HAS_DEPSF90_TRUE@am__append_9 = coinhsl/common/deps90.f90
+@COIN_HAS_HSL_MC68_TRUE@am__append_10 = coinhsl/hsl_mc68/C/hsl_mc68i_ciface.f90
+@COIN_HAS_HSL_MC68_TRUE@am__append_11 = coinhsl/hsl_mc68/C/hsl_mc68i.h
+@COIN_HAS_HSL_MA77_TRUE@am__append_12 = coinhsl/hsl_ma77/hsl_ma77d.f90 coinhsl/hsl_ma77/C/hsl_ma77d_ciface.f90
+@COIN_HAS_HSL_MA77_TRUE@am__append_13 = coinhsl/hsl_ma77/C/hsl_ma77d.h
+@COIN_HAS_HSL_MA77S_TRUE@am__append_14 = coinhsl/hsl_ma77/hsl_ma77s.f90 coinhsl/hsl_ma77/C/hsl_ma77s_ciface.f90
+@COIN_HAS_HSL_MA86_TRUE@am__append_15 = coinhsl/hsl_ma86/hsl_ma86d.f90 coinhsl/hsl_ma86/C/hsl_ma86d_ciface.f90
+@COIN_HAS_HSL_MA86_TRUE@am__append_16 = coinhsl/hsl_ma86/C/hsl_ma86d.h
+@COIN_HAS_HSL_MA86S_TRUE@am__append_17 = coinhsl/hsl_ma86/hsl_ma86s.f90 coinhsl/hsl_ma86/C/hsl_ma86s_ciface.f90
+@COIN_HAS_HSL_MA97_TRUE@am__append_18 = coinhsl/hsl_ma97/hsl_ma97d.f90 coinhsl/hsl_ma97/C/hsl_ma97d_ciface.f90
+@COIN_HAS_HSL_MA97_TRUE@am__append_19 = coinhsl/hsl_ma97/C/hsl_ma97d.h
+@COIN_HAS_HSL_MA97S_TRUE@am__append_20 = coinhsl/hsl_ma97/hsl_ma97s.f90 coinhsl/hsl_ma97/C/hsl_ma97s_ciface.f90
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/configure.ac
@@ -154,21 +161,40 @@ am__DEPENDENCIES_1 =
 libcoinhsl_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
 am__dirstamp = $(am__leading_dot)dirstamp
 @COIN_HAS_MC19_TRUE@am__objects_1 = coinhsl/mc19/mc19d.lo
-@COIN_HAS_MA27_TRUE@am__objects_2 = coinhsl/ma27/ma27d.lo
-@COIN_HAS_MA28_TRUE@am__objects_3 = coinhsl/ma28/ma28d.lo
-@COIN_HAS_MA57_TRUE@am__objects_4 = coinhsl/ma57/ma57d.lo
-@COIN_HAS_DEPSF90_TRUE@am__objects_5 = coinhsl/common/deps90.lo
-@COIN_HAS_HSL_MC68_TRUE@am__objects_6 = coinhsl/hsl_mc68/C/hsl_mc68i_ciface.lo
-@COIN_HAS_HSL_MA77_TRUE@am__objects_7 = coinhsl/hsl_ma77/hsl_ma77d.lo \
+@COIN_HAS_MC19S_TRUE@am__objects_2 = coinhsl/mc19/mc19s.lo
+@COIN_HAS_MA27_TRUE@am__objects_3 = coinhsl/ma27/ma27d.lo
+@COIN_HAS_MA27S_TRUE@am__objects_4 = coinhsl/ma27/ma27s.lo
+@COIN_HAS_MA28_TRUE@am__objects_5 = coinhsl/ma28/ma28d.lo
+@COIN_HAS_MA28S_TRUE@am__objects_6 = coinhsl/ma28/ma28s.lo
+@COIN_HAS_MA57_TRUE@am__objects_7 = coinhsl/ma57/ma57d.lo
+@COIN_HAS_MA57S_TRUE@am__objects_8 = coinhsl/ma57/ma57s.lo
+@COIN_HAS_DEPSF90_TRUE@am__objects_9 = coinhsl/common/deps90.lo
+@COIN_HAS_HSL_MC68_TRUE@am__objects_10 = coinhsl/hsl_mc68/C/hsl_mc68i_ciface.lo
+@COIN_HAS_HSL_MA77_TRUE@am__objects_11 =  \
+@COIN_HAS_HSL_MA77_TRUE@	coinhsl/hsl_ma77/hsl_ma77d.lo \
 @COIN_HAS_HSL_MA77_TRUE@	coinhsl/hsl_ma77/C/hsl_ma77d_ciface.lo
-@COIN_HAS_HSL_MA86_TRUE@am__objects_8 = coinhsl/hsl_ma86/hsl_ma86d.lo \
+@COIN_HAS_HSL_MA77S_TRUE@am__objects_12 =  \
+@COIN_HAS_HSL_MA77S_TRUE@	coinhsl/hsl_ma77/hsl_ma77s.lo \
+@COIN_HAS_HSL_MA77S_TRUE@	coinhsl/hsl_ma77/C/hsl_ma77s_ciface.lo
+@COIN_HAS_HSL_MA86_TRUE@am__objects_13 =  \
+@COIN_HAS_HSL_MA86_TRUE@	coinhsl/hsl_ma86/hsl_ma86d.lo \
 @COIN_HAS_HSL_MA86_TRUE@	coinhsl/hsl_ma86/C/hsl_ma86d_ciface.lo
-@COIN_HAS_HSL_MA97_TRUE@am__objects_9 = coinhsl/hsl_ma97/hsl_ma97d.lo \
+@COIN_HAS_HSL_MA86S_TRUE@am__objects_14 =  \
+@COIN_HAS_HSL_MA86S_TRUE@	coinhsl/hsl_ma86/hsl_ma86s.lo \
+@COIN_HAS_HSL_MA86S_TRUE@	coinhsl/hsl_ma86/C/hsl_ma86s_ciface.lo
+@COIN_HAS_HSL_MA97_TRUE@am__objects_15 =  \
+@COIN_HAS_HSL_MA97_TRUE@	coinhsl/hsl_ma97/hsl_ma97d.lo \
 @COIN_HAS_HSL_MA97_TRUE@	coinhsl/hsl_ma97/C/hsl_ma97d_ciface.lo
+@COIN_HAS_HSL_MA97S_TRUE@am__objects_16 =  \
+@COIN_HAS_HSL_MA97S_TRUE@	coinhsl/hsl_ma97/hsl_ma97s.lo \
+@COIN_HAS_HSL_MA97S_TRUE@	coinhsl/hsl_ma97/C/hsl_ma97s_ciface.lo
 am_libcoinhsl_la_OBJECTS = coinhsl/common/deps.lo $(am__objects_1) \
 	$(am__objects_2) $(am__objects_3) $(am__objects_4) \
 	$(am__objects_5) $(am__objects_6) $(am__objects_7) \
-	$(am__objects_8) $(am__objects_9) metis_adapter.lo
+	$(am__objects_8) $(am__objects_9) $(am__objects_10) \
+	$(am__objects_11) $(am__objects_12) $(am__objects_13) \
+	$(am__objects_14) $(am__objects_15) $(am__objects_16) \
+	metis_adapter.lo
 libcoinhsl_la_OBJECTS = $(am_libcoinhsl_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -414,13 +440,16 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 includecoindir = $(includedir)/coin-or/hsl
-includecoin_HEADERS = CoinHslConfig.h $(am__append_7) $(am__append_9) \
-	$(am__append_11) $(am__append_13)
+includecoin_HEADERS = CoinHslConfig.h $(am__append_11) \
+	$(am__append_13) $(am__append_16) $(am__append_19)
 lib_LTLIBRARIES = libcoinhsl.la
 libcoinhsl_la_SOURCES = coinhsl/common/deps.f $(am__append_1) \
 	$(am__append_2) $(am__append_3) $(am__append_4) \
-	$(am__append_5) $(am__append_6) $(am__append_8) \
-	$(am__append_10) $(am__append_12) metis_adapter.c
+	$(am__append_5) $(am__append_6) $(am__append_7) \
+	$(am__append_8) $(am__append_9) $(am__append_10) \
+	$(am__append_12) $(am__append_14) $(am__append_15) \
+	$(am__append_17) $(am__append_18) $(am__append_20) \
+	metis_adapter.c
 @COIN_HAS_METIS_TRUE@AM_FCFLAGS = $(FC_DEFINE)metis_nodend=coinmetis_nodend $(FCFLAGS_f90)
 @COIN_HAS_METIS_TRUE@AM_FFLAGS = $(FC_DEFINE)METIS_NODEND=COINMETIS_NODEND $(FCFLAGS_f)
 AM_CFLAGS = $(HSL_CFLAGS)
@@ -554,6 +583,8 @@ coinhsl/mc19/$(DEPDIR)/$(am__dirstamp):
 	@: > coinhsl/mc19/$(DEPDIR)/$(am__dirstamp)
 coinhsl/mc19/mc19d.lo: coinhsl/mc19/$(am__dirstamp) \
 	coinhsl/mc19/$(DEPDIR)/$(am__dirstamp)
+coinhsl/mc19/mc19s.lo: coinhsl/mc19/$(am__dirstamp) \
+	coinhsl/mc19/$(DEPDIR)/$(am__dirstamp)
 coinhsl/ma27/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/ma27
 	@: > coinhsl/ma27/$(am__dirstamp)
@@ -561,6 +592,8 @@ coinhsl/ma27/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/ma27/$(DEPDIR)
 	@: > coinhsl/ma27/$(DEPDIR)/$(am__dirstamp)
 coinhsl/ma27/ma27d.lo: coinhsl/ma27/$(am__dirstamp) \
+	coinhsl/ma27/$(DEPDIR)/$(am__dirstamp)
+coinhsl/ma27/ma27s.lo: coinhsl/ma27/$(am__dirstamp) \
 	coinhsl/ma27/$(DEPDIR)/$(am__dirstamp)
 coinhsl/ma28/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/ma28
@@ -570,6 +603,8 @@ coinhsl/ma28/$(DEPDIR)/$(am__dirstamp):
 	@: > coinhsl/ma28/$(DEPDIR)/$(am__dirstamp)
 coinhsl/ma28/ma28d.lo: coinhsl/ma28/$(am__dirstamp) \
 	coinhsl/ma28/$(DEPDIR)/$(am__dirstamp)
+coinhsl/ma28/ma28s.lo: coinhsl/ma28/$(am__dirstamp) \
+	coinhsl/ma28/$(DEPDIR)/$(am__dirstamp)
 coinhsl/ma57/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/ma57
 	@: > coinhsl/ma57/$(am__dirstamp)
@@ -577,6 +612,8 @@ coinhsl/ma57/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/ma57/$(DEPDIR)
 	@: > coinhsl/ma57/$(DEPDIR)/$(am__dirstamp)
 coinhsl/ma57/ma57d.lo: coinhsl/ma57/$(am__dirstamp) \
+	coinhsl/ma57/$(DEPDIR)/$(am__dirstamp)
+coinhsl/ma57/ma57s.lo: coinhsl/ma57/$(am__dirstamp) \
 	coinhsl/ma57/$(DEPDIR)/$(am__dirstamp)
 coinhsl/common/deps90.lo: coinhsl/common/$(am__dirstamp) \
 	coinhsl/common/$(DEPDIR)/$(am__dirstamp)
@@ -606,6 +643,11 @@ coinhsl/hsl_ma77/C/$(DEPDIR)/$(am__dirstamp):
 coinhsl/hsl_ma77/C/hsl_ma77d_ciface.lo:  \
 	coinhsl/hsl_ma77/C/$(am__dirstamp) \
 	coinhsl/hsl_ma77/C/$(DEPDIR)/$(am__dirstamp)
+coinhsl/hsl_ma77/hsl_ma77s.lo: coinhsl/hsl_ma77/$(am__dirstamp) \
+	coinhsl/hsl_ma77/$(DEPDIR)/$(am__dirstamp)
+coinhsl/hsl_ma77/C/hsl_ma77s_ciface.lo:  \
+	coinhsl/hsl_ma77/C/$(am__dirstamp) \
+	coinhsl/hsl_ma77/C/$(DEPDIR)/$(am__dirstamp)
 coinhsl/hsl_ma86/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/hsl_ma86
 	@: > coinhsl/hsl_ma86/$(am__dirstamp)
@@ -623,6 +665,11 @@ coinhsl/hsl_ma86/C/$(DEPDIR)/$(am__dirstamp):
 coinhsl/hsl_ma86/C/hsl_ma86d_ciface.lo:  \
 	coinhsl/hsl_ma86/C/$(am__dirstamp) \
 	coinhsl/hsl_ma86/C/$(DEPDIR)/$(am__dirstamp)
+coinhsl/hsl_ma86/hsl_ma86s.lo: coinhsl/hsl_ma86/$(am__dirstamp) \
+	coinhsl/hsl_ma86/$(DEPDIR)/$(am__dirstamp)
+coinhsl/hsl_ma86/C/hsl_ma86s_ciface.lo:  \
+	coinhsl/hsl_ma86/C/$(am__dirstamp) \
+	coinhsl/hsl_ma86/C/$(DEPDIR)/$(am__dirstamp)
 coinhsl/hsl_ma97/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/hsl_ma97
 	@: > coinhsl/hsl_ma97/$(am__dirstamp)
@@ -638,6 +685,11 @@ coinhsl/hsl_ma97/C/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) coinhsl/hsl_ma97/C/$(DEPDIR)
 	@: > coinhsl/hsl_ma97/C/$(DEPDIR)/$(am__dirstamp)
 coinhsl/hsl_ma97/C/hsl_ma97d_ciface.lo:  \
+	coinhsl/hsl_ma97/C/$(am__dirstamp) \
+	coinhsl/hsl_ma97/C/$(DEPDIR)/$(am__dirstamp)
+coinhsl/hsl_ma97/hsl_ma97s.lo: coinhsl/hsl_ma97/$(am__dirstamp) \
+	coinhsl/hsl_ma97/$(DEPDIR)/$(am__dirstamp)
+coinhsl/hsl_ma97/C/hsl_ma97s_ciface.lo:  \
 	coinhsl/hsl_ma97/C/$(am__dirstamp) \
 	coinhsl/hsl_ma97/C/$(DEPDIR)/$(am__dirstamp)
 
@@ -1005,6 +1057,9 @@ uninstall-am: uninstall-includecoinHEADERS uninstall-libLTLIBRARIES \
 
 .PRECIOUS: Makefile
 
+@COIN_HAS_HSL_MA77S_TRUE@  # includecoin_HEADERS += coinhsl/hsl_ma77/C/hsl_ma77s.h
+@COIN_HAS_HSL_MA86S_TRUE@  # includecoin_HEADERS += coinhsl/hsl_ma86/C/hsl_ma86s.h
+@COIN_HAS_HSL_MA97S_TRUE@  # includecoin_HEADERS += coinhsl/hsl_ma97/C/hsl_ma97s.h
 @COIN_HAS_METIS_TRUE@  # call coinmetis_nodend from metis_adapter.c instead of metis_nodend in common/deps90.f90
 @COIN_HAS_METIS_TRUE@  # call COINMETIS_NODEND from metis_adapter.c instead of METIS_NODEND in ma57/ma57d.f
 $(ma77).lo: deps90.lo

--- a/config.h.in
+++ b/config.h.in
@@ -6,23 +6,44 @@
 /* Define to 1 if MA27 is available. */
 #undef COINHSL_HAS_MA27
 
+/* Define to 1 if MA27S is available. */
+#undef COINHSL_HAS_MA27S
+
 /* Define to 1 if MA28 is available. */
 #undef COINHSL_HAS_MA28
+
+/* Define to 1 if MA28S is available. */
+#undef COINHSL_HAS_MA28S
 
 /* Define to 1 if MA57 is available. */
 #undef COINHSL_HAS_MA57
 
+/* Define to 1 if MA57S is available. */
+#undef COINHSL_HAS_MA57S
+
 /* Define to 1 if MA77 is available. */
 #undef COINHSL_HAS_MA77
+
+/* Define to 1 if MA77S is available. */
+#undef COINHSL_HAS_MA77S
 
 /* Define to 1 if MA86 is available. */
 #undef COINHSL_HAS_MA86
 
+/* Define to 1 if MA86S is available. */
+#undef COINHSL_HAS_MA86S
+
 /* Define to 1 if MA97 is available. */
 #undef COINHSL_HAS_MA97
 
+/* Define to 1 if MA97S is available. */
+#undef COINHSL_HAS_MA97S
+
 /* Define to 1 if MC19 is available. */
 #undef COINHSL_HAS_MC19
+
+/* Define to 1 if MC19S is available. */
+#undef COINHSL_HAS_MC19S
 
 /* Define to 1 if MC68 is available. */
 #undef COINHSL_HAS_MC68

--- a/configure
+++ b/configure
@@ -662,6 +662,20 @@ COIN_HAS_DEPSF90_FALSE
 COIN_HAS_DEPSF90_TRUE
 COIN_HAS_HSL_MC68_FALSE
 COIN_HAS_HSL_MC68_TRUE
+COIN_HAS_HSL_MA97S_FALSE
+COIN_HAS_HSL_MA97S_TRUE
+COIN_HAS_HSL_MA86S_FALSE
+COIN_HAS_HSL_MA86S_TRUE
+COIN_HAS_HSL_MA77S_FALSE
+COIN_HAS_HSL_MA77S_TRUE
+COIN_HAS_MA57S_FALSE
+COIN_HAS_MA57S_TRUE
+COIN_HAS_MA28S_FALSE
+COIN_HAS_MA28S_TRUE
+COIN_HAS_MA27S_FALSE
+COIN_HAS_MA27S_TRUE
+COIN_HAS_MC19S_FALSE
+COIN_HAS_MC19S_TRUE
 COIN_HAS_HSL_MA97_FALSE
 COIN_HAS_HSL_MA97_TRUE
 COIN_HAS_HSL_MA86_FALSE
@@ -20216,6 +20230,12 @@ $as_echo "no" >&6; }
     pkg_short_errors=""
   fi
 
+  # Check whether -static option of pkg-config should be used when requesting libs
+  pkg_static=
+  if test -n "$PKG_CONFIG" ; then
+    case "$LDFLAGS" in "-static" | "* -static*" ) pkg_static=--static ;; esac
+  fi
+
    if test -n "$PKG_CONFIG"; then
   COIN_HAS_PKGCONFIG_TRUE=
   COIN_HAS_PKGCONFIG_FALSE='#'
@@ -20236,6 +20256,11 @@ $as_echo "$as_me: $PKG_CONFIG path is \"$COIN_PKG_CONFIG_PATH\"" >&6;}
   fi
 
 
+
+
+
+
+# check for single precision files
 
 
 
@@ -20396,6 +20421,167 @@ fi
 else
   COIN_HAS_HSL_MA97_TRUE='#'
   COIN_HAS_HSL_MA97_FALSE=
+fi
+
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MC19S" >&5
+$as_echo_n "checking for MC19S... " >&6; }
+if test -r "$srcdir/coinhsl/mc19/mc19s.f" ; then
+
+$as_echo "#define COINHSL_HAS_MC19S 1" >>confdefs.h
+
+  coin_has_mc19s=yes
+else
+  coin_has_mc19s=no
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_mc19s" >&5
+$as_echo "$coin_has_mc19s" >&6; }
+ if test $coin_has_mc19s = yes; then
+  COIN_HAS_MC19S_TRUE=
+  COIN_HAS_MC19S_FALSE='#'
+else
+  COIN_HAS_MC19S_TRUE='#'
+  COIN_HAS_MC19S_FALSE=
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MA27S" >&5
+$as_echo_n "checking for MA27S... " >&6; }
+if test -r "$srcdir/coinhsl/ma27/ma27s.f" ; then
+
+$as_echo "#define COINHSL_HAS_MA27S 1" >>confdefs.h
+
+  coin_has_ma27s=yes
+else
+  coin_has_ma27s=no
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_ma27s" >&5
+$as_echo "$coin_has_ma27s" >&6; }
+ if test $coin_has_ma27s = yes; then
+  COIN_HAS_MA27S_TRUE=
+  COIN_HAS_MA27S_FALSE='#'
+else
+  COIN_HAS_MA27S_TRUE='#'
+  COIN_HAS_MA27S_FALSE=
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MA28S" >&5
+$as_echo_n "checking for MA28S... " >&6; }
+if test -r "$srcdir/coinhsl/ma28/ma28s.f" ; then
+
+$as_echo "#define COINHSL_HAS_MA28S 1" >>confdefs.h
+
+  coin_has_ma28s=yes
+else
+  coin_has_ma28s=no
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_ma28s" >&5
+$as_echo "$coin_has_ma28s" >&6; }
+ if test $coin_has_ma28s = yes; then
+  COIN_HAS_MA28S_TRUE=
+  COIN_HAS_MA28S_FALSE='#'
+else
+  COIN_HAS_MA28S_TRUE='#'
+  COIN_HAS_MA28S_FALSE=
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MA57S" >&5
+$as_echo_n "checking for MA57S... " >&6; }
+if test -r "$srcdir/coinhsl/ma57/ma57s.f" ; then
+
+$as_echo "#define COINHSL_HAS_MA57S 1" >>confdefs.h
+
+  coin_has_ma57s=yes
+else
+  coin_has_ma57s=no
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_ma57s" >&5
+$as_echo "$coin_has_ma57s" >&6; }
+ if test $coin_has_ma57s = yes; then
+  COIN_HAS_MA57S_TRUE=
+  COIN_HAS_MA57S_FALSE='#'
+else
+  COIN_HAS_MA57S_TRUE='#'
+  COIN_HAS_MA57S_FALSE=
+fi
+
+
+# enabel these when .h files exist from HSL
+if test -n "$FC" ; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for MA77S" >&5
+$as_echo_n "checking for MA77S... " >&6; }
+   if test -r "$srcdir/coinhsl/hsl_ma77/hsl_ma77s.f90" ; then
+
+$as_echo "#define COINHSL_HAS_MA77S 1" >>confdefs.h
+
+     coin_has_hsl_ma77s=yes
+   else
+     coin_has_hsl_ma77s=no
+   fi
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_hsl_ma77s" >&5
+$as_echo "$coin_has_hsl_ma77s" >&6; }
+else
+  coin_has_hsl_ma77s=no
+fi
+ if test $coin_has_hsl_ma77s = yes; then
+  COIN_HAS_HSL_MA77S_TRUE=
+  COIN_HAS_HSL_MA77S_FALSE='#'
+else
+  COIN_HAS_HSL_MA77S_TRUE='#'
+  COIN_HAS_HSL_MA77S_FALSE=
+fi
+
+
+if test -n "$FC" ; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for MA86S" >&5
+$as_echo_n "checking for MA86S... " >&6; }
+   if test -r "$srcdir/coinhsl/hsl_ma86/hsl_ma86s.f90" ; then
+
+$as_echo "#define COINHSL_HAS_MA86S 1" >>confdefs.h
+
+     coin_has_hsl_ma86s=yes
+   else
+     coin_has_hsl_ma86s=no
+   fi
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_hsl_ma86s" >&5
+$as_echo "$coin_has_hsl_ma86s" >&6; }
+else
+  coin_has_hsl_ma86s=no
+fi
+ if test $coin_has_hsl_ma86s = yes; then
+  COIN_HAS_HSL_MA86S_TRUE=
+  COIN_HAS_HSL_MA86S_FALSE='#'
+else
+  COIN_HAS_HSL_MA86S_TRUE='#'
+  COIN_HAS_HSL_MA86S_FALSE=
+fi
+
+
+if test -n "$FC" ; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for MA97S" >&5
+$as_echo_n "checking for MA97S... " >&6; }
+   if test -r "$srcdir/coinhsl/hsl_ma97/hsl_ma97s.f90" ; then
+
+$as_echo "#define COINHSL_HAS_MA97S 1" >>confdefs.h
+
+     coin_has_hsl_ma97s=yes
+   else
+     coin_has_hsl_ma97s=no
+   fi
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $coin_has_hsl_ma97s" >&5
+$as_echo "$coin_has_hsl_ma97s" >&6; }
+else
+  coin_has_hsl_ma97s=no
+fi
+ if test $coin_has_hsl_ma97s = yes; then
+  COIN_HAS_HSL_MA97S_TRUE=
+  COIN_HAS_HSL_MA97S_FALSE='#'
+else
+  COIN_HAS_HSL_MA97S_TRUE='#'
+  COIN_HAS_HSL_MA97S_FALSE=
 fi
 
 
@@ -20639,7 +20825,7 @@ $as_echo "$as_me: lapack_pcfiles is \"$lapack_pcfiles\"" >&6;}
   LIBS="$lapack_lflags $LIBS"
   if test -n "$lapack_pcfiles" ; then
 
-      temp_LFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --libs $lapack_pcfiles`
+      temp_LFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --libs $pkg_static $lapack_pcfiles`
       LIBS="$temp_LFLAGS $LIBS"
     fi
 
@@ -20950,6 +21136,7 @@ $as_echo "$ac_success" >&6; }
         # check for 64-bit sequential MKL in $LIB
         old_IFS="$IFS"
         IFS=";"
+        coin_mkl=""
         for d in $LIB ; do
           # turn $d into unix-style short path (no spaces); cannot do -us, so first do -ws, then -u
           d=`cygpath -ws "$d"`
@@ -20967,6 +21154,7 @@ $as_echo "$ac_success" >&6; }
           fi
         done
         IFS="$old_IFS"
+        if test -n "$coin_mkl" ; then
 
   ac_save_LIBS="$LIBS"
   LIBS="$coin_mkl $LIBS"
@@ -21036,10 +21224,11 @@ $as_echo "$ac_success" >&6; }
 
   if test $ac_success = yes ; then
     coin_has_lapack=yes
-             lapack_lflags="$coin_mkl"
+                lapack_lflags="$coin_mkl"
 
   fi
 
+        fi
       ;;
 
       *-darwin*)
@@ -21216,7 +21405,7 @@ $as_echo "yes" >&6; }
 
   if test -n "lapack" ; then
 
-      temp_LFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --libs lapack`
+      temp_LFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --libs $pkg_static lapack`
       LIBS="$temp_LFLAGS $LIBS"
     fi
 
@@ -22204,7 +22393,7 @@ $as_echo "$as_me: FINALIZE_FLAGS for HSL:" >&6;}
 
       if test -n "${HSL_PCFILES}" ; then
         temp_CFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --cflags ${HSL_PCFILES}`
-        temp_LFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --libs ${HSL_PCFILES}`
+        temp_LFLAGS=`PKG_CONFIG_PATH="$COIN_PKG_CONFIG_PATH" $PKG_CONFIG --libs $pkg_static ${HSL_PCFILES}`
         HSL_CFLAGS="$temp_CFLAGS ${HSL_CFLAGS}"
         HSL_LFLAGS="$temp_LFLAGS ${HSL_LFLAGS}"
       fi
@@ -22425,6 +22614,34 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${COIN_HAS_HSL_MA97_TRUE}" && test -z "${COIN_HAS_HSL_MA97_FALSE}"; then
   as_fn_error $? "conditional \"COIN_HAS_HSL_MA97\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_MC19S_TRUE}" && test -z "${COIN_HAS_MC19S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_MC19S\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_MA27S_TRUE}" && test -z "${COIN_HAS_MA27S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_MA27S\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_MA28S_TRUE}" && test -z "${COIN_HAS_MA28S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_MA28S\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_MA57S_TRUE}" && test -z "${COIN_HAS_MA57S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_MA57S\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_HSL_MA77S_TRUE}" && test -z "${COIN_HAS_HSL_MA77S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_HSL_MA77S\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_HSL_MA86S_TRUE}" && test -z "${COIN_HAS_HSL_MA86S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_HSL_MA86S\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COIN_HAS_HSL_MA97S_TRUE}" && test -z "${COIN_HAS_HSL_MA97S_FALSE}"; then
+  as_fn_error $? "conditional \"COIN_HAS_HSL_MA97S\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${COIN_HAS_HSL_MC68_TRUE}" && test -z "${COIN_HAS_HSL_MC68_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -121,10 +121,10 @@ MY_CHECK_HSLFILE_S(mc19)
 MY_CHECK_HSLFILE_S(ma27)
 MY_CHECK_HSLFILE_S(ma28)
 MY_CHECK_HSLFILE_S(ma57)
-# enabel these when .h files exist from HSL
-MY_CHECK_HSLFILE_F90_S(hsl_ma77)
-MY_CHECK_HSLFILE_F90_S(hsl_ma86)
-MY_CHECK_HSLFILE_F90_S(hsl_ma97)
+# enable these when .h files exist from HSL
+#MY_CHECK_HSLFILE_F90_S(hsl_ma77)
+#MY_CHECK_HSLFILE_F90_S(hsl_ma86)
+#MY_CHECK_HSLFILE_F90_S(hsl_ma97)
 
 coin_has_hsl_mc68=no
 if test -n "$FC"; then

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,35 @@ fi
 AM_CONDITIONAL(m4_toupper(COIN_HAS_$1),[test $coin_has_$1 = yes])
 ])
 
+# check for single precision files
+AC_DEFUN([MY_CHECK_HSLFILE_S],
+[AC_MSG_CHECKING([for m4_toupper(m4_bpatsubst($1S, hsl_))])
+if test -r "$srcdir/coinhsl/$1/$1s.f" ; then
+  AC_DEFINE(m4_toupper(COINHSL_HAS_$1S), [1], Define to 1 if m4_toupper(m4_bpatsubst($1S, hsl_)) is available.)
+  coin_has_$1s=yes
+else
+  coin_has_$1s=no
+fi
+AC_MSG_RESULT($coin_has_$1s)
+AM_CONDITIONAL(m4_toupper(COIN_HAS_$1S),[test $coin_has_$1s = yes])
+])
+
+AC_DEFUN([MY_CHECK_HSLFILE_F90_S],
+[if test -n "$FC" ; then
+   AC_MSG_CHECKING([for m4_toupper(m4_bpatsubst($1S, hsl_))])
+   if test -r "$srcdir/coinhsl/$1/$1s.f90" ; then
+     AC_DEFINE([COINHSL_HAS_]m4_toupper(m4_bpatsubst($1S, hsl_)), [1], Define to 1 if m4_toupper(m4_bpatsubst($1S, hsl_)) is available.)
+     coin_has_$1s=yes
+   else
+     coin_has_$1s=no
+   fi
+   AC_MSG_RESULT($coin_has_$1s)
+else
+  coin_has_$1s=no
+fi
+AM_CONDITIONAL(m4_toupper(COIN_HAS_$1S),[test $coin_has_$1s = yes])
+])
+
 MY_CHECK_HSLFILE(mc19)
 MY_CHECK_HSLFILE(ma27)
 MY_CHECK_HSLFILE(ma28)
@@ -87,6 +116,15 @@ MY_CHECK_HSLFILE(ma57)
 MY_CHECK_HSLFILE_F90(hsl_ma77)
 MY_CHECK_HSLFILE_F90(hsl_ma86)
 MY_CHECK_HSLFILE_F90(hsl_ma97)
+
+MY_CHECK_HSLFILE_S(mc19)
+MY_CHECK_HSLFILE_S(ma27)
+MY_CHECK_HSLFILE_S(ma28)
+MY_CHECK_HSLFILE_S(ma57)
+# enabel these when .h files exist from HSL
+MY_CHECK_HSLFILE_F90_S(hsl_ma77)
+MY_CHECK_HSLFILE_F90_S(hsl_ma86)
+MY_CHECK_HSLFILE_F90_S(hsl_ma97)
 
 coin_has_hsl_mc68=no
 if test -n "$FC"; then


### PR DESCRIPTION
This change will build single precision routines if the user has downloaded them from HSL. As of now the HSL for IPOPT archive (http://www.hsl.rl.ac.uk/ipopt/) doesn't include the single precision files, but the individual routines may be downloaded in both precisions and then manually added to the `coinhsl` directory. Also as far as I know, C header files for hsl_ma77s, hsl_ma86s and hsl_ma97s don't exist anywhere, hence why they are commented out in Makefile.am.

When I build this with single precision files, and then try to configure Ipopt using the `--with-hsl` flag, the name mangling check isn't able to identify ma27 being in the library.